### PR TITLE
Add missing dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: imagepy
 channels:
   - conda-forge
 dependencies:
+  - matplotlib
   - numba
   - numpy-stl
   - openpyxl
@@ -10,6 +11,7 @@ dependencies:
   - pypubsub
   - read-roi
   - scikit-image
+  - scipy
   - shapely
   - wxpython
   - xlrd

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+matplotlib
 scikit-image
+scipy
 shapely
 wxpython
 numba


### PR DESCRIPTION
Installing with `pip install imagepy` on windows, trying to run `python -m imagepy`
It turns out that matplotlib and scipy were missing libraries 