### PR TITLE
Install Pystackreg with pip instead of conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - openpyxl
   - pandas
   - pydicom
-  - pystackreg
   - pypubsub
   - read-roi
   - scikit-image
@@ -18,3 +17,4 @@ dependencies:
   - markdown
   - pip:
     - moderngl
+    - pystackreg


### PR DESCRIPTION
Pystackreg is missing for windows architecture on conda while with pip it works