### PR TITLE
quick fix of roi import plg

### DIFF
--- a/imagepy/menus/File/Import/roi_plg.py
+++ b/imagepy/menus/File/Import/roi_plg.py
@@ -7,7 +7,7 @@ import numpy as np
 import read_roi
 from imagepy.core.engine import Free
 from imagepy import IPy
-from skimage.draw import polygon
+from skimage.draw import polygon, ellipse
 
 class Plugin(Free):
     """load_ij_roi: use read_roi and th pass to shapely objects"""
@@ -27,5 +27,18 @@ class Plugin(Free):
         ls = read_roi.read_roi_zip(para['path'])
         img = np.zeros((para['height'], para['width']), dtype=np.int32)
         for i in ls:
-            img[polygon(ls[i]['y'], ls[i]['x'], img.shape)] = int(i)
+            current_roi = ls[i]
+            roi_type = current_roi["type"]
+            if roi_type is "freehand":
+                rs, cs = polygon(ls[i]['y'], ls[i]['x'], img.shape)
+            elif roi_type is "oval":
+                rs, cs = ellipse(current_roi["top"]+current_roi["height"]/2,
+                        current_roi["left"]+current_roi["width"]/2,
+                        current_roi["height"]/2,
+                        current_roi["width"]/2)
+            try:
+                ind = int(i)
+            except Exception:
+                ind = int(i.split("-")[-1])
+            img[rs, cs] = ind
         IPy.show_img([img], para['name'])


### PR DESCRIPTION
It was not possible to load shapes other than "polygon". Added `ellipse` support for instance. Will add the adaptors for other shapes.