### PR TITLE
No need to manually install shapely

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Simply unzip the archive and run the ImagePy.bat file.
 This will open a command line window and open the GUI of ImagePy.
 
 ### - Using pip
-In a command-prompt type `pip install imagepy`.  
-On Windows you currently need to first install shapely using conda.   
+In a command-prompt type `pip install imagepy`.
+~~On Windows you currently need to first install shapely using conda.~~ This should also work for windows, now that shapely is available via pip.
 Once installed, ImagePy can be run by typing `python -m imagepy` in a command prompt.
 
 


### PR DESCRIPTION
Just edited the readme that was previously mentioning that shapely should have been installed manually. Not needed anymore as shapely is available via pip for windows too since recently.