### PR TITLE
Fix: linspace accepts integer divisions only

### DIFF
--- a/imagepy/tools/Measure/profile_tol.py
+++ b/imagepy/tools/Measure/profile_tol.py
@@ -131,8 +131,8 @@ class Plugin(Tool):
         (x1, y1), (x2, y2) = body[0]
         dx, dy = x2-x1, y2-y1
         n = max(abs(dx), abs(dy)) + 1
-        xs = np.linspace(x1, x2, n).round().astype(np.int16)
-        ys = np.linspace(y1, y2, n).round().astype(np.int16)
+        xs = np.linspace(x1, x2, int(n)).round().astype(np.int16)
+        ys = np.linspace(y1, y2, int(n)).round().astype(np.int16)
         msk = (xs>=0) * (xs<img.shape[1])
         msk*= (ys>=0) * (ys<img.shape[0])
         ix = np.arange(len(xs))

--- a/imagepy/tools/Network/graphcut_tol.py
+++ b/imagepy/tools/Network/graphcut_tol.py
@@ -41,8 +41,8 @@ def cut(img, lines):
         cx, cy = i
         dx, dy = cx-ox, cy-oy
         n = max(abs(dx), abs(dy)) + 1
-        xs = np.linspace(cx, ox, n).round().astype(np.int16)
-        ys = np.linspace(cy, oy, n).round().astype(np.int16)
+        xs = np.linspace(cx, ox, n.astype(np.uint16)).round().astype(np.int16)
+        ys = np.linspace(cy, oy, n.astype(np.uint16)).round().astype(np.int16)
         for x,y in zip(xs, ys):
             for dxy in [(1,0),(0,1)]:
                 xx = x + dxy[0]

--- a/imagepy/tools/Network/graphpen_tol.py
+++ b/imagepy/tools/Network/graphpen_tol.py
@@ -42,8 +42,8 @@ def draw(img, lines):
         cx, cy = i
         dx, dy = cx-ox, cy-oy
         n = max(abs(dx), abs(dy)) + 1
-        xs = np.linspace(ox, cx, n).round().astype(np.int16)
-        ys = np.linspace(oy, cy, n).round().astype(np.int16)
+        xs = np.linspace(ox, cx, n.astype(np.uint16)).round().astype(np.int16)
+        ys = np.linspace(oy, cy, n.astype(np.uint16)).round().astype(np.int16)
         for x,y in zip(xs, ys):
             if x<0 or x>img.shape[1]: continue
             if y<0 or y>img.shape[0]: continue


### PR DESCRIPTION
I checked all the occurences of *linspace* using
```bash
grep -rn "linspace" ./
```
from the main directory of ImagePy. In all the cases when the third argument of *linspace* was float, I probed the given method in debugging mode and they indeed failed. After these corrections, the *linspace* issue is solved.